### PR TITLE
Handles ! notation with not set case

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ function parse (obj, cases, filter) {
             ? merge(result, parse(obj[i], cases, filter), filter)
             : merge(result, obj[i], filter)
         }
-      } else if (i[0] === '!' && cases[not = i.slice(1)] !== void 0) {
+      } else if (i[0] === '!') {
         if (!cases[not]) {
           result = isObj(obj[i])
             ? merge(result, parse(obj[i], cases, filter), filter)

--- a/test/index.js
+++ b/test/index.js
@@ -185,7 +185,7 @@ test('deletions', function (t) {
 })
 
 test('! (negative) notation', function (t) {
-  t.plan(2)
+  t.plan(3)
 
   t.same(
     c({
@@ -224,6 +224,15 @@ test('! (negative) notation', function (t) {
       }
     },
     'complex object with ! notation'
+  )
+
+  t.same(
+    c({
+      val: 'originalVal',
+      '!$something': 'notSomething'
+    }, {}),
+    'notSomething',
+    'parse object with ! notation when case does not exist'
   )
 })
 


### PR DESCRIPTION
Not sure if this is the intended behaviour.
If a case is not set, should the not "!" operator but applied? Or only when it's set but `false`?

If a case is not set, the `'!$something'` key and value will be merged to the final result.
Also should I check for `$` as the case prefix? Does not seem to be imposed.

/cc @youzi @jimdebeer 
